### PR TITLE
Removed java versions from the build workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [ 8.0.192, 8, 11.0.3, 17, 18-ea ]
+        java-version: [ 11.0.3, 17 ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK ${{ matrix.java-version }}


### PR DESCRIPTION
Just removed java 8 and java 18ae from the maven building workflow as it can cause failures and I don't believe these versions or being used in the project.

Will add more workflows later and tests just for the heck of it if I have time.